### PR TITLE
ci: add action.yml for docs workflow

### DIFF
--- a/publish-docs/action.yml
+++ b/publish-docs/action.yml
@@ -1,0 +1,18 @@
+name: 'Build docs'
+description: 'Trigger docs workflow'
+inputs:
+  token:
+    description: 'Access token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Trigger docs build
+      env:
+        DISPATCH_API: https://api.github.com/repos/Breakthrough-Energy/docs/actions/workflows/2386877/dispatches
+      run: |
+        curl -XPOST -H "Authorization: token ${{ inputs.token }}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Content-Type: application/json" ${{ env.DISPATCH_API }} \
+        --data '{"ref": "refs/heads/master"}'
+      shell: bash


### PR DESCRIPTION
### Purpose
Define the action to trigger docs workflow in one place so it can be reused from multiple repositories. Here is a [branch](https://github.com/Breakthrough-Energy/PowerSimData/compare/jon/action?expand=1) showing what the usage looks like. Admittedly, we aren't saving much here, but the goal is mostly to set up the pattern.

### What it does
There are only a few supported action types we can declare, this particular one is a [composite](https://docs.github.com/en/actions/creating-actions/creating-a-composite-run-steps-action) action which happens to just run the curl command. It takes a token as input, so there are no secrets defined in this repo - it's passed in from the consuming workflow (e.g. one defined in PowerSimData).

### Testing
I did a test before the open source release, but it will be validated by merging the corresponding PR and seeing it still trigger the docs workflow.

### Time to review
5 mins