### PR TITLE
ci: docker action to regenerate Pipfile.lock

### DIFF
--- a/update-packages/Dockerfile
+++ b/update-packages/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.8.3
+
+RUN apt-get update -y
+RUN pip install -U pip pipenv
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/update-packages/action.yml
+++ b/update-packages/action.yml
@@ -1,0 +1,11 @@
+name: 'Update packages'
+description: 'Regenerate Pipfile.lock'
+inputs:
+  repo-dir:
+    description: 'Path to the repository root'
+    required: true
+runs:
+  using: 'docker'
+  image: Dockerfile
+  args:
+    - ${{ inputs.repo-dir }}

--- a/update-packages/entrypoint.sh
+++ b/update-packages/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $1
+pipenv lock --pre


### PR DESCRIPTION
### Purpose
Define action that can be used in a workflow to update packages and create a PR (this only does the update packages part). The [docs](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action) for reference. 

### What it does
* the dockerfile allows github actions to build the image which will be used in a workflow
* the `repo-dir` input is needed since the working path will be one level up from where the Pipfile is (in some cases)
* `action.yml` specifies input/output and what to run

### Testing
Ran in postreise and got it to generate a PR https://github.com/Breakthrough-Energy/PostREISE/pull/217

I used this [branch](https://github.com/Breakthrough-Energy/PostREISE/compare/jon/test?expand=1) for testing, but will delete and create a new PR in PostREISE and elsewhere referencing the `main` branch here once this is merged.

### Time to review
5 min