### PR TITLE
feat: add summary of package updates

### DIFF
--- a/update-packages/Dockerfile
+++ b/update-packages/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.8.3
 RUN apt-get update -y
 RUN pip install -U pip pipenv
 COPY entrypoint.sh /entrypoint.sh
+COPY pkgdiff.py /pkgdiff.py
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/update-packages/action.yml
+++ b/update-packages/action.yml
@@ -4,6 +4,9 @@ inputs:
   repo-dir:
     description: 'Path to the repository root'
     required: true
+outputs:
+  summary:
+    description: 'Summary of changes'
 runs:
   using: 'docker'
   image: Dockerfile

--- a/update-packages/entrypoint.sh
+++ b/update-packages/entrypoint.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/bin/sh -l
 
 cd $1
+cp Pipfile.lock Pipfile.lock.old
 pipenv lock --pre
+summary=$(python /pkgdiff.py Pipfile.lock.old Pipfile.lock)
+rm Pipfile.lock.old
+echo "::set-output name=summary::$summary"

--- a/update-packages/pkgdiff.py
+++ b/update-packages/pkgdiff.py
@@ -1,0 +1,44 @@
+import json
+
+
+def parse_version(section):
+    return {
+        name: info["version"][2:] for name, info in section.items() if "version" in info
+    }
+
+
+def to_dict(lockfile):
+    with open(lockfile) as f:
+        obj = json.load(f)
+
+    default = parse_version(obj["default"])
+    develop = parse_version(obj["develop"])
+    return {k: v for d in (default, develop) for k, v in d.items()}
+
+
+def compare(original, updated):
+    old = to_dict(original)
+    new = to_dict(updated)
+    result = {}
+    result["Additions"] = {
+        name: version for name, version in new.items() if name not in old
+    }
+    result["Deletions"] = {
+        name: version for name, version in old.items() if name not in new
+    }
+    result["Updates"] = {
+        name: f"{version} -> {new[name]}"
+        for name, version in old.items()
+        if name in new and new[name] != version
+    }
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    try:
+        result = compare(sys.argv[1], sys.argv[2])
+        print(json.dumps(result))
+    except Exception as e:
+        print(f"Error trying to generate comparsion: {e}")


### PR DESCRIPTION
### Purpose
Add python script to parse updates to Pipfile.lock so we can create a summary in the resulting PR description

### What it does
Basic comparison to get packages that were added or removed, along with version updates. The result is a python dict which is printed as json and saved as an output by the action so it can be referenced in subsequent steps (e.g. the step to create PR). See [example](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#writing-the-action-code) usage of the output syntax. There is probably a smarter algorithm but this is fast enough for our use case (pretty much instant when I test locally). 

Note: the reason for using `json.dumps` is apparently github actions truncates multiline outputs, so we'll need to format it within the workflow. 

### Testing
Used this branch in PostREISE to generate a PR and got the correct content in the description.

### Time to review
10 mins