### PR TITLE
feat: add workflow to trigger docker build in plug

### DIFF
--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -1,0 +1,18 @@
+name: 'Build docker image'
+description: 'Trigger docker build workflow'
+inputs:
+  token:
+    description: 'Access token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Trigger docker build
+      env:
+        DISPATCH_API: https://api.github.com/repos/Breakthrough-Energy/plug/actions/workflows/12413223/dispatches
+      run: |
+        curl -XPOST -H "Authorization: token ${{ inputs.token }}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Content-Type: application/json" ${{ env.DISPATCH_API }} \
+        --data '{"ref": "refs/heads/main"}'
+      shell: bash


### PR DESCRIPTION
### Purpose
Define action to simplify triggering the docker build. Same things we did for the docs build, but with the target repo and workflow id replaced.

### Testing
Ran the curl command manually, passing my branch with `push: false` as the github ref - see [workflow logs](https://github.com/Breakthrough-Energy/plug/runs/3437107016?check_suite_focus=true). 