### PR TITLE
feat: add generalized workflow trigger

### DIFF
--- a/workflow-trigger/action.yml
+++ b/workflow-trigger/action.yml
@@ -1,0 +1,28 @@
+name: 'Trigger workflow'
+description: 'Trigger workflow in another repository'
+inputs:
+  repo:
+    description: 'Repository where the workflow is hosted'
+    required: true
+  branch:
+    description: 'Branch to run the workflow on'
+    required: false
+    default: 'main'
+  workflow_id:
+    description: 'The id of the workflow to run'
+    required: true
+  token:
+    description: 'Access token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Trigger workflow
+      env:
+        DISPATCH_API: https://api.github.com/repos/Breakthrough-Energy/${{ inputs.repo }}/actions/workflows/${{ inputs.workflow_id }}/dispatches
+      run: |
+        curl -XPOST -H "Authorization: token ${{ inputs.token }}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Content-Type: application/json" ${{ env.DISPATCH_API }} \
+        --data '{"ref": "refs/heads/${{ inputs.branch }}"}'
+      shell: bash


### PR DESCRIPTION
### Purpose
Parameterize the action to trigger a workflow in another repository, which we can now use to build docker images and replace the existing docs build. Once this is merged, I will update the docs workflows to use this instead and delete the existing docs trigger action.yml in this repo. 

### Testing
I modified the docs workflow in powersimdata to point to this action, passing in parameters to run the docker build workflow in plug, on my branch which is setup not to actually push the image. See the logs from [powersimdata](https://github.com/Breakthrough-Energy/PowerSimData/runs/3437292745) and the resulting workflow in [plug](https://github.com/Breakthrough-Energy/plug/runs/3437294407). 