### PR TITLE
chore: make input optional and default to current directory

### DIFF
--- a/update-packages/action.yml
+++ b/update-packages/action.yml
@@ -3,7 +3,8 @@ description: 'Regenerate Pipfile.lock'
 inputs:
   repo-dir:
     description: 'Path to the repository root'
-    required: true
+    required: false
+    default: '.'
 outputs:
   summary:
     description: 'Summary of changes'


### PR DESCRIPTION
### Purpose
The workflows using this action previously assumed the need to change to a sub-directory, but this is no longer the case, so it should be optional. For example, in PreREISE, we would also checkout PowerSimData in an adjacent directory, making it necessary for all steps in the workflow to specify that they are run from the PreREISE directory. Since we have the packages on PyPI, we don't need to checkout PowerSimData anymore, and can simplify the workflow yaml. 

### Where to look
See the workflow in PreREISE [here](https://github.com/Breakthrough-Energy/PreREISE/blob/2dec5377b611627b90746b05291c45ab36792fa2/.github/workflows/packages.yml) for how it's currently used, and this [branch](https://github.com/Breakthrough-Energy/PreREISE/compare/jon/setup?expand=1) for how it will be updated pending this being merged.

### Testing
I ran the workflow in my test repo and successfully generated this PR https://github.com/jon-hagg/test-ci/pull/1