### PR TITLE
feat: pass workflow inputs

### DIFF
--- a/workflow-trigger/action.yml
+++ b/workflow-trigger/action.yml
@@ -14,6 +14,11 @@ inputs:
   token:
     description: 'Access token'
     required: true
+  inputs:
+    description: 'Workflow specific inputs'
+    required: false
+    default: '{}'
+
 runs:
   using: 'composite'
   steps:
@@ -24,5 +29,5 @@ runs:
         curl -XPOST -H "Authorization: token ${{ inputs.token }}" \
         -H "Accept: application/vnd.github.v3+json" \
         -H "Content-Type: application/json" ${{ env.DISPATCH_API }} \
-        --data '{"ref": "refs/heads/${{ inputs.branch }}"}'
+        --data '{"ref": "refs/heads/${{ inputs.branch }}", "inputs": ${{ inputs.inputs }} }'
       shell: bash


### PR DESCRIPTION
### Purpose
We have workflows that can be run manually, via github's ui, which can have a user provided input. Main example is the docker image tag, where we can specify `latest` or `stable`. We also trigger these workflows from other ones, but don't have a way to override the default. Example: we want to publish the `postreise:stable` docker image when a new package is released to pypi, but have to run that manually because the default tag is `latest`. This PR fixes that by allowing a workflow to specify what a user would.

### What the code is doing
Allow a workflow using this action to provide inputs to the target workflow (the one being triggered). 

### Testing
Tested in https://github.com/jenhagg/test-ci, both without the `inputs` and with a non default value.

### Where to look
The commit history in the test-ci repo could be useful. Here are the docs about the REST API https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event


### Time estimate
5 min, or more if you want to read the docs
